### PR TITLE
[gtest] Update to use the newer gtest API.

### DIFF
--- a/test/AbstractDomainPropertyTest.h
+++ b/test/AbstractDomainPropertyTest.h
@@ -54,7 +54,7 @@ class AbstractDomainPropertyTest : public ::testing::Test {
   }
 };
 
-TYPED_TEST_CASE_P(AbstractDomainPropertyTest);
+TYPED_TEST_SUITE_P(AbstractDomainPropertyTest);
 
 TYPED_TEST_P(AbstractDomainPropertyTest, Basics) {
   using Domain = TypeParam;
@@ -204,11 +204,11 @@ TYPED_TEST_P(AbstractDomainPropertyTest, Relations) {
   }
 }
 
-REGISTER_TYPED_TEST_CASE_P(AbstractDomainPropertyTest,
-                           Basics,
-                           JoinMeetBounds,
-                           Idempotence,
-                           Reflexivity,
-                           Commutativity,
-                           Absorption,
-                           Relations);
+REGISTER_TYPED_TEST_SUITE_P(AbstractDomainPropertyTest,
+                            Basics,
+                            JoinMeetBounds,
+                            Idempotence,
+                            Reflexivity,
+                            Commutativity,
+                            Absorption,
+                            Relations);

--- a/test/DisjointUnionAbstractDomainTest.cpp
+++ b/test/DisjointUnionAbstractDomainTest.cpp
@@ -23,9 +23,9 @@ using IntDomain = ConstantAbstractDomain<int>;
 using StringDomain = ConstantAbstractDomain<std::string>;
 using IntStringDomain = DisjointUnionAbstractDomain<IntDomain, StringDomain>;
 
-INSTANTIATE_TYPED_TEST_CASE_P(DisjointUnionAbstractDomain,
-                              AbstractDomainPropertyTest,
-                              IntStringDomain);
+INSTANTIATE_TYPED_TEST_SUITE_P(DisjointUnionAbstractDomain,
+                               AbstractDomainPropertyTest,
+                               IntStringDomain);
 
 template <>
 std::vector<IntStringDomain>

--- a/test/HashedSetAbstractDomainTest.cpp
+++ b/test/HashedSetAbstractDomainTest.cpp
@@ -18,9 +18,9 @@ using namespace sparta;
 
 using Domain = HashedSetAbstractDomain<std::string>;
 
-INSTANTIATE_TYPED_TEST_CASE_P(HashedSetAbstractDomain,
-                              AbstractDomainPropertyTest,
-                              Domain);
+INSTANTIATE_TYPED_TEST_SUITE_P(HashedSetAbstractDomain,
+                               AbstractDomainPropertyTest,
+                               Domain);
 
 template <>
 std::vector<Domain>

--- a/test/PatriciaTreeMapAbstractPartitionTest.cpp
+++ b/test/PatriciaTreeMapAbstractPartitionTest.cpp
@@ -21,9 +21,9 @@ using Domain = HashedSetAbstractDomain<std::string>;
 
 using Partition = PatriciaTreeMapAbstractPartition<uint32_t, Domain>;
 
-INSTANTIATE_TYPED_TEST_CASE_P(PatriciaTreeMapAbstractPartition,
-                              AbstractDomainPropertyTest,
-                              Partition);
+INSTANTIATE_TYPED_TEST_SUITE_P(PatriciaTreeMapAbstractPartition,
+                               AbstractDomainPropertyTest,
+                               Partition);
 
 template <>
 std::vector<Partition>

--- a/test/ReducedProductAbstractDomainTest.cpp
+++ b/test/ReducedProductAbstractDomainTest.cpp
@@ -78,9 +78,9 @@ class D0xD1xD2 final
   }
 };
 
-INSTANTIATE_TYPED_TEST_CASE_P(ReducedProductAbstractDomain,
-                              AbstractDomainPropertyTest,
-                              D0xD1xD2);
+INSTANTIATE_TYPED_TEST_SUITE_P(ReducedProductAbstractDomain,
+                               AbstractDomainPropertyTest,
+                               D0xD1xD2);
 
 template <>
 std::vector<D0xD1xD2>


### PR DESCRIPTION
Summary:
This patch eliminates a few deprecation warnings when building
the `sparta_test` gtest.

SPARTA's cmake config obtains gtest from the gtest master branch
(see: SPARTA/cmake_modules/gtest.cmake.in).  This patch renames
the test macros to match the newer gtest API.
