### PR TITLE
CI should fail when there's a test failing

### DIFF
--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -4,12 +4,25 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+TEST_FAILED=0
+FAILED_TESTS=$""
+
+failed_test() {
+  ((TEST_FAILED++))
+  FAILED_TESTS=$"$FAILED_TESTS\n - $1\t[FAILED]"
+}
+
 for test in *_test; do
   if [[ -f "$test" ]]; then
-    ./"$test"
+    ./"$test" || failed_test $test
   else
     # Wildcard did not expand into any file (i.e. files don't exist)
     echo "Tests not found. Please make sure you are in the build directory."
     exit 2
   fi
 done
+
+if [[ $TEST_FAILED -ne 0 ]]; then
+  printf $"$TEST_FAILED test(s) has failed.$FAILED_TESTS\n"
+  exit 1
+fi

--- a/test/InterproceduralAnalyzerTest.cpp
+++ b/test/InterproceduralAnalyzerTest.cpp
@@ -680,6 +680,8 @@ void test1() {
   EXPECT_TRUE(inter.registry.get(&fun6).is_top());
   // 7 is unreached
   EXPECT_TRUE(inter.registry.get(&fun7).is_top());
+
+  FAIL();
 }
 
 TEST(AnalyzerTest, test1) { test1(); }


### PR DESCRIPTION
I am still testing the CI setup. It looks like the run_all_tests.sh script doesn't return an error code when there are failed tests. Correcting this. Expecting this PR to fail. 